### PR TITLE
Send greeting using bot-level send methods

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -24,10 +24,16 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
     markup = InlineKeyboardMarkup(kb)
     caption = "👾 Привет! Добро пожаловать в Bugman!\n\nЖми «Играть» — Mini App откроется внутри Telegram."
 
+    send_kwargs = {
+        "chat_id": update.effective_chat.id,
+        "caption": caption,
+        "reply_markup": markup,
+    }
+
     try:
-        await update.message.reply_animation(animation=MEDIA_URL, caption=caption, reply_markup=markup)
+        await context.bot.send_animation(animation=MEDIA_URL, **send_kwargs)
     except Exception:
-        await update.message.reply_photo(photo=MEDIA_URL, caption=caption, reply_markup=markup)
+        await context.bot.send_photo(photo=MEDIA_URL, **send_kwargs)
 
 def run_bot():
     app = ApplicationBuilder().token(TOKEN).build()


### PR DESCRIPTION
## Summary
- use `context.bot.send_animation` and `context.bot.send_photo` with explicit chat ID
- fall back to sending a photo if animation fails

## Testing
- `python -m py_compile bot.py`
- `TOKEN=dummy python - <<'PY'
import asyncio
from types import SimpleNamespace
from bot import start

class MockBot:
    def __init__(self):
        self.sent = []
    async def send_animation(self, animation, **kwargs):
        self.sent.append(('animation', animation, kwargs))
    async def send_photo(self, photo, **kwargs):
        self.sent.append(('photo', photo, kwargs))

class MockChat:
    id = 123

class MockUpdate:
    effective_chat = MockChat()

class MockContext(SimpleNamespace):
    pass

async def test():
    bot = MockBot()
    context = MockContext(bot=bot)
    update = MockUpdate()
    await start(update, context)
    print(bot.sent)

asyncio.run(test())
PY`

------
https://chatgpt.com/codex/tasks/task_e_6899d077e5248331b3d57e10e62a08c1