### PR TITLE
Ensure welcome message appears on start

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -32,7 +32,11 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
     try:
         await update.message.reply_animation(animation=MEDIA_URL, caption=caption, reply_markup=markup)
     except Exception:
-        await update.message.reply_photo(photo=MEDIA_URL, caption=caption, reply_markup=markup)
+        try:
+            await update.message.reply_photo(photo=MEDIA_URL, caption=caption, reply_markup=markup)
+        except Exception:
+            # Если отправка медиа не удалась, хотя бы приветствуем текстом
+            await update.message.reply_text(text=caption, reply_markup=markup)
 
 # ---------- Aiohttp health ----------
 async def health(_: web.Request) -> web.Response:


### PR DESCRIPTION
## Summary
- send fallback text if media fails when users press /start

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_689a08d9a8908331975e0798ff70d5b6