### PR TITLE
Add FastAPI leaderboard server

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 python-telegram-bot==20.3
 aiohttp==3.9.5
 httpx~=0.24.0
+fastapi==0.111.0
+uvicorn==0.30.1

--- a/server.py
+++ b/server.py
@@ -1,0 +1,36 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+import sqlite3
+
+app = FastAPI()
+conn = sqlite3.connect("scores.db", check_same_thread=False)
+conn.execute(
+    "CREATE TABLE IF NOT EXISTS scores (user_id INTEGER PRIMARY KEY, username TEXT, score INTEGER)"
+)
+
+
+class Score(BaseModel):
+    userId: int
+    username: str
+    score: int
+
+
+@app.post("/score")
+def post_score(s: Score):
+    cur = conn.execute("SELECT score FROM scores WHERE user_id = ?", (s.userId,))
+    row = cur.fetchone()
+    if not row or s.score > row[0]:
+        conn.execute(
+            "REPLACE INTO scores (user_id, username, score) VALUES (?, ?, ?)",
+            (s.userId, s.username, s.score),
+        )
+        conn.commit()
+    return {"status": "ok"}
+
+
+@app.get("/leaderboard")
+def get_leaderboard(limit: int = 10):
+    cur = conn.execute(
+        "SELECT username, score FROM scores ORDER BY score DESC LIMIT ?", (limit,)
+    )
+    return [{"username": u, "score": sc} for u, sc in cur.fetchall()]


### PR DESCRIPTION
## Summary
- add FastAPI server with SQLite backend for player scores
- expose endpoints for submitting scores and fetching leaderboard
- include FastAPI and Uvicorn in requirements

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_689a57eb1124833197f5b72908cc722e