### PR TITLE
Enable CORS for leaderboard

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,8 +1,16 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 import sqlite3
 
 app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 conn = sqlite3.connect("scores.db", check_same_thread=False)
 conn.execute(
     "CREATE TABLE IF NOT EXISTS scores (user_id INTEGER PRIMARY KEY, username TEXT, score INTEGER)"


### PR DESCRIPTION
## Summary
- allow cross-origin requests so mini app can fetch leaderboard

## Testing
- `python -m py_compile bot.py server.py`


------
https://chatgpt.com/codex/tasks/task_e_689a602128fc833194c4bcc0ba3536b1