### PR TITLE
feat(api): global leaderboard server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.env
+leaderboard.db
+__pycache__/
+

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: uvicorn server:app --host 0.0.0.0 --port $PORT
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Bugman Leaderboard
+
+FastAPI server providing a global leaderboard for the Bugman Telegram mini game.
+
+## Run locally
+
+```
+pip install -r requirements.txt
+echo -e "BOT_TOKEN=<твой токен>\nPORT=8080" > .env
+uvicorn server:app --host 0.0.0.0 --port $PORT --reload
+```
+
+## Deploy on Render
+
+The repository already contains a `Procfile` compatible with Render:
+
+```
+web: uvicorn server:app --host 0.0.0.0 --port $PORT
+```
+
+Create a new Web Service on Render pointing to the repo. After deployment the
+server will be reachable at the URL provided by Render, e.g.
+`https://bugman-bot.onrender.com`.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ aiohttp==3.9.5
 httpx~=0.24.0
 fastapi==0.111.0
 uvicorn==0.30.1
+aiosqlite==0.20.0
+python-dotenv==1.0.1

--- a/server.py
+++ b/server.py
@@ -1,9 +1,41 @@
-from fastapi import FastAPI
+"""FastAPI server providing a global leaderboard for Bugman."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from datetime import datetime
+from os import getenv
+from urllib.parse import parse_qsl
+
+import aiosqlite
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
-import sqlite3
+from dotenv import load_dotenv
+
+
+load_dotenv()
+
+BOT_TOKEN = getenv("BOT_TOKEN", "")
+PORT = int(getenv("PORT", "8080"))
+
+DATABASE = "leaderboard.db"
+
+CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS players (
+  id TEXT PRIMARY KEY,
+  username TEXT,
+  display_name TEXT,
+  best_score INTEGER DEFAULT 0,
+  updated_at TEXT
+);
+"""
+
 
 app = FastAPI()
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
@@ -11,34 +43,125 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-conn = sqlite3.connect("scores.db", check_same_thread=False)
-conn.execute(
-    "CREATE TABLE IF NOT EXISTS scores (user_id INTEGER PRIMARY KEY, username TEXT, score INTEGER)"
-)
 
 
-class Score(BaseModel):
-    userId: int
-    username: str
+class ScoreIn(BaseModel):
+    initData: str
     score: int
 
 
+def verify_init_data(init_data: str) -> dict | None:
+    """Validate Telegram WebApp initData string."""
+
+    if not BOT_TOKEN:
+        return None
+
+    data = dict(parse_qsl(init_data, strict_parsing=True))
+    init_hash = data.pop("hash", None)
+    if not init_hash:
+        return None
+
+    data_check_string = "\n".join(f"{k}={v}" for k, v in sorted(data.items()))
+    secret_key = hmac.new(b"WebAppData", BOT_TOKEN.encode(), hashlib.sha256).digest()
+    calculated_hash = hmac.new(
+        secret_key, data_check_string.encode(), hashlib.sha256
+    ).hexdigest()
+
+    if not hmac.compare_digest(calculated_hash, init_hash):
+        return None
+
+    return data
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    app.state.db = await aiosqlite.connect(DATABASE)
+    await app.state.db.execute(CREATE_TABLE_SQL)
+    await app.state.db.commit()
+
+
+@app.on_event("shutdown")
+async def shutdown() -> None:
+    await app.state.db.close()
+
+
 @app.post("/score")
-def post_score(s: Score):
-    cur = conn.execute("SELECT score FROM scores WHERE user_id = ?", (s.userId,))
-    row = cur.fetchone()
-    if not row or s.score > row[0]:
-        conn.execute(
-            "REPLACE INTO scores (user_id, username, score) VALUES (?, ?, ?)",
-            (s.userId, s.username, s.score),
+async def post_score(payload: ScoreIn):
+    data = verify_init_data(payload.initData)
+    if not data:
+        raise HTTPException(status_code=401, detail="Invalid initData")
+
+    user_json = data.get("user")
+    if not user_json:
+        raise HTTPException(status_code=400, detail="User missing")
+
+    user = json.loads(user_json)
+    user_id = str(user.get("id"))
+    username = user.get("username")
+    first_name = user.get("first_name")
+    display_name = username or first_name or f"Player {user_id[-4:]}"
+
+    db = app.state.db
+    async with db.execute(
+        "SELECT best_score FROM players WHERE id = ?", (user_id,)
+    ) as cur:
+        row = await cur.fetchone()
+    prev_best = row[0] if row else 0
+
+    now = datetime.utcnow().isoformat()
+    if payload.score > prev_best:
+        query = (
+            "INSERT INTO players (id, username, display_name, best_score, updated_at) "
+            "VALUES (?, ?, ?, ?, ?) "
+            "ON CONFLICT(id) DO UPDATE SET "
+            "username=excluded.username, display_name=excluded.display_name, "
+            "best_score=excluded.best_score, updated_at=excluded.updated_at"
         )
-        conn.commit()
-    return {"status": "ok"}
+        params = (user_id, username, display_name, payload.score, now)
+        best = payload.score
+    else:
+        query = (
+            "INSERT INTO players (id, username, display_name, best_score, updated_at) "
+            "VALUES (?, ?, ?, ?, ?) "
+            "ON CONFLICT(id) DO UPDATE SET "
+            "username=excluded.username, display_name=excluded.display_name"
+        )
+        params = (user_id, username, display_name, prev_best, now)
+        best = prev_best
+
+    await db.execute(query, params)
+    await db.commit()
+
+    me = {
+        "id": user_id,
+        "display_name": display_name,
+        "username": username,
+        "best_score": best,
+    }
+    return {"ok": True, "me": me}
 
 
 @app.get("/leaderboard")
-def get_leaderboard(limit: int = 10):
-    cur = conn.execute(
-        "SELECT username, score FROM scores ORDER BY score DESC LIMIT ?", (limit,)
-    )
-    return [{"username": u, "score": sc} for u, sc in cur.fetchall()]
+async def get_leaderboard(limit: int = 100, offset: int = 0):
+    if limit > 200:
+        limit = 200
+
+    db = app.state.db
+    async with db.execute(
+        "SELECT display_name, username, best_score FROM players ORDER BY best_score DESC "
+        "LIMIT ? OFFSET ?",
+        (limit, offset),
+    ) as cur:
+        rows = await cur.fetchall()
+
+    items = [
+        {"display_name": d, "username": u, "best_score": s} for d, u, s in rows
+    ]
+    return {"items": items}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("server:app", host="0.0.0.0", port=PORT)
+


### PR DESCRIPTION
## Summary
- implement FastAPI server with global leaderboard stored in SQLite
- verify Telegram initData, update best scores, and expose leaderboard endpoint
- add deployment files and docs for running on Render

## Testing
- `python -m py_compile server.py`
- `pip install -r requirements.txt`
- `python - <<'PY'
from fastapi.testclient import TestClient
import server
with TestClient(server.app) as client:
    resp = client.get('/leaderboard')
    print(resp.status_code, resp.json())
PY`


------
https://chatgpt.com/codex/tasks/task_e_689a669371408331ad0ceb987da66453