### PR TITLE
fix(api): CORS+preflight, clearer errors, debug echo, robust initData

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,19 @@ Create a new Web Service on Render pointing to the repo. After deployment the
 server will be reachable at the URL provided by Render, e.g.
 `https://bugman-bot.onrender.com`.
 
+## Troubleshooting
+
+When `DEBUG=true` in your `.env`, you can inspect parsed user data:
+
+```bash
+curl -X POST http://localhost:8080/debug/echo_user \
+  -H 'Content-Type: application/json' \
+  -d '{"initData":"<real-init-data>"}'
+```
+
+Example error responses from `/score`:
+
+- Missing fields: `{"ok":false,"error":"bad_request","reason":"missing initData or score"}`
+- Invalid init data: `{"ok":false,"error":"invalid_init_data"}`
+- Too many requests: `{"ok":false,"error":"too_many_requests","reason":"rate_limited"}`
+


### PR DESCRIPTION
## Summary
- handle CORS preflight explicitly and add `/health` and root heartbeat
- parse initData robustly and validate users, with clearer JSON error responses & rate limiting
- add optional debug echo endpoint when DEBUG=true

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_689af07f3a6c8331b85a95ec42341df1