### PR TITLE
fix(auth): raw initData HMAC (no decode) + multi-token use

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ EOF
 uvicorn server:app --host 0.0.0.0 --port $PORT --reload
 ```
 
+Для успешной проверки подписи `BOT_TOKEN`/`BOT_TOKENS` должны соответствовать тому
+боту, из которого открывается Mini App.
+
 ## Deploy on Render
 
 The repository already contains a `Procfile` compatible with Render:


### PR DESCRIPTION
## Summary
- verify initData HMAC using raw query string without decoding
- load bot tokens from BOT_TOKEN/BOT_TOKENS per request
- document that tokens must match the bot launching the Mini App

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_689af61eaf9c8331bfb8435da5dbff00