### PR TITLE
fix(auth): build data_check_string from decoded pairs (parse_qsl) + multi-token

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ uvicorn server:app --host 0.0.0.0 --port $PORT --reload
 ```
 
 Для успешной проверки подписи `BOT_TOKEN`/`BOT_TOKENS` должны соответствовать тому
-боту, из которого открывается Mini App.
+боту, из которого открывается Mini App. Строка для подписи строится из декодированных
+значений, как в `parse_qsl`.
 
 ## Deploy on Render
 
@@ -35,12 +36,18 @@ server will be reachable at the URL provided by Render, e.g.
 
 ## Troubleshooting
 
-When `DEBUG=true` in your `.env`, you can verify raw init data:
+When `DEBUG=true` in your `.env`, you can verify init data:
 
 ```bash
-curl -X POST http://localhost:8080/debug/verify \
-  -H 'Content-Type: application/json' \
-  -d '{"initData":"<real-init-data>"}'
+curl -G http://localhost:8080/auth_check --data-urlencode "initData=<real-init-data>"
+```
+
+To inspect the string used for signing:
+
+```bash
+curl -G http://localhost:8080/auth_check \
+  --data-urlencode "initData=<real-init-data>" \
+  --data-urlencode "echo=1"
 ```
 
 Example error responses from `/score`:


### PR DESCRIPTION
## Summary
- verify WebApp initData using decoded key-value pairs and HMAC across multiple tokens
- add debug `/auth_check` endpoint with optional data string echo
- document parse_qsl signing and new auth_check usage

## Testing
- `python -m py_compile server.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689af8a4cc3c83319196b728ccf8c009